### PR TITLE
Use U.S. first names instead of German

### DIFF
--- a/labs/HelloWorld/README.md
+++ b/labs/HelloWorld/README.md
@@ -133,7 +133,7 @@ Copy and paste in the following new Intent definition:
       "slots":[
         {
           "name":"firstname",
-          "type":"AMAZON.DE_FIRST_NAME"
+          "type":"AMAZON.US_FIRST_NAME"
         }
       ]
     }


### PR DESCRIPTION
I think this was a typo, it should probably use US first names instead of German first names since this tutorial is in English?