### PR TITLE
Update the sample code of progressive-response based on the api change…

### DIFF
--- a/handling-responses/progressive-response/lambda/custom/Messages.js
+++ b/handling-responses/progressive-response/lambda/custom/Messages.js
@@ -20,6 +20,8 @@ const DIRECTIVESERVICEMESSAGE = 'Please wait...';
 
 const DIRECTIVEERRORMESSAGE = 'Cannot enqueue a progressive direcitve.';
 
+const GETEVENTSERRORMESSAGE = 'Cannot get events from wiki, thanks for using the history buff skill';
+
 const GOODBYE = 'Bye! Thanks for using the history buff skill';
 
 const UNHANDLED = 'This skill doesn\'t support that. Please ask something else.';
@@ -36,6 +38,7 @@ module.exports = {
     'HELPREPROMPTTEXT': HELPREPROMPTTEXT,
     'DIRECTIVESERVICEMESSAGE': DIRECTIVESERVICEMESSAGE,
     'DIRECTIVEERRORMESSAGE': DIRECTIVEERRORMESSAGE,
+    'GETEVENTSERRORMESSAGE' : GETEVENTSERRORMESSAGE,
     'GOODBYE': GOODBYE,
     'UNHANDLED': UNHANDLED
 };


### PR DESCRIPTION

Previously,  skills use a multi-thread architecture to invoke the Progressive Response API. In the case when skill service response is received before directive service responses, the directive service responses will be ignored.
Now, the skill does not dispatch the skill response until both the Progressive Response API and the developer’s service call are returned.