### PR TITLE
Bug fix on AMAZON.RepeatIntent of Cookbook labs Recipe

### DIFF
--- a/labs/Recipe/src/index.js
+++ b/labs/Recipe/src/index.js
@@ -157,7 +157,7 @@
       },
       'AMAZON.RepeatIntent': function () {
           if (!this.attributes['currentStep'] ) {
-              this.attributes['currentStep'] = 1;
+              this.attributes['currentStep'] = 0;
           } else {
               this.attributes['currentStep'] = this.attributes['currentStep'] - 1;
           }


### PR DESCRIPTION
Since 'AMAZON.NextIntent' will do `incrementStep.call(this, 1);` every time it handles request, when there is no `this.attributes['currentStep']` stored, we probably should start with 0, rather than 1.