### PR TITLE
[Entity Resolution Quiz Demo] fix package.json syntax error

### DIFF
--- a/feature-demos/skill-demo-entity-resolution-quiz/lambda/custom/package.json
+++ b/feature-demos/skill-demo-entity-resolution-quiz/lambda/custom/package.json
@@ -7,6 +7,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "ask-sdk-core": "^2.0.0",
+    "ask-sdk-core": "^2.0.0"
   }
 }


### PR DESCRIPTION
##  Problems
`package.json` has syntax error, so we can not run `npm insstall` command in this example.

## env

```
$ node -v
v10.5.0

$ npm -v
6.1.0
```

## Reproduce

```
$ git clone git@github.com:alexa/alexa-cookbook.git
$ cd alexa-cookbook/feature-demos/skill-demo-entity-resolution-quiz
$ npm i

npm ERR! file /develop/node/alexa/alexa-cookbook/feature-demos/skill-demo-entity-resolution-quiz/lambda/custom/package.json
npm ERR! code EJSONPARSE
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected token } in JSON at position 213 while parsing near '...-core": "^2.0.0",
npm ERR! JSON.parse   }
npm ERR! JSON.parse }
npm ERR! JSON.parse '
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.

npm ERR! A complete log of this run can be found in:
npm ERR!     /develop/.npm/_logs/2018-07-21T02_23_38_361Z-debug.log
```

or

```
$ cat alexa-cookbook/feature-demos/skill-demo-entity-resolution-quiz/lambda/custom/package.json | jq .
parse error: Expected another key-value pair at line 11, column 3
```

## Changes
Fix `package.json`'s syntax error.