### PR TITLE
Update cli-task-6.md

### DIFF
--- a/labs/CLI/cli-task-6.md
+++ b/labs/CLI/cli-task-6.md
@@ -25,7 +25,7 @@ A new in-skill product will be created as a JSON file in a folder called `/isps/
 
 5. Open the in-skill product JSON file (`/isps/entitlement/premium-greeting.json`) in your code editor.
 
-6. Copy a completed version by [clicking here](https://github.com/alexa/alexa-cookbook/edit/master/labs/CLI/assets/premium-greetings.json) and paste it into your in-skill product JSON file.
+6. Copy a completed version by [clicking here](https://github.com/alexa/alexa-cookbook/blob/master/labs/CLI/assets/premium-greetings.json) and paste it into your in-skill product JSON file.
 
 7. Return to your terminal window and type in `ask deploy -t isp` to deploy your product.
 


### PR DESCRIPTION
Fix typo in the path of premium-greetings.json

*Issue #, if available:* if a user that does not have edit permissions visits /edit, he will be prompted to fork the repo instead of being presented with the content of the file.

*Description of changes:* changing  /edit to /blob fixes the issue and provides the intended behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
