### PR TITLE
Prevent Vending Expired Video URL in Video app feature demo

### DIFF
--- a/feature-demos/skill-demo-personalization/skill.json
+++ b/feature-demos/skill-demo-personalization/skill.json
@@ -27,18 +27,6 @@
       {
         "name": "alexa::person_id:read"
       }
-    ],
-    "privacyAndCompliance": {
-      "allowsPurchases": false,
-      "locales": {
-        "en-US": {
-          "privacyPolicyUrl": "http://developer.amazon.com/sampleTestingUrl"
-        }
-      },
-      "isExportCompliant": true,
-      "containsAds": false,
-      "isChildDirected": false,
-      "usesPersonalInfo": false
-    }
+    ]
   }
 }

--- a/feature-demos/skill-demo-videoapp-directive/lambda/custom/index.js
+++ b/feature-demos/skill-demo-videoapp-directive/lambda/custom/index.js
@@ -3,7 +3,7 @@ const Alexa = require('ask-sdk-core');
 const HELP_MESSAGE = 'This is a simple demo. Just open the skill to see the video.';
 const ERROR_MESSAGE = 'Sorry, an error occurred in the demo. Please check the logs.';
 const STOP_MESSAGE = 'Goodbye!';
-const videoUrl = 'https://s3.amazonaws.com/ask-samples-resources/videos/underconfirmation.mp4';
+// NOTE: set the video url location below
 
 function supportsVideo(handlerInput) {
   const hasVideo =
@@ -23,6 +23,12 @@ const LaunchRequestHandler = {
     return request.type === 'LaunchRequest';
   },
   handle(handlerInput) {
+    // video location
+    const videoUrl = 'https://s3.amazonaws.com/ask-samples-resources/videos/underconfirmation.mp4';
+    // Use this isntead if you want to use your own video and your skill is Alexa-hosted. Be sure to require the util.js file
+    // const util = require('util.js');
+    // const videoUrl = util.getS3PreSignedUrl('Media/myVideo.mp4');
+    
     if (supportsVideo(handlerInput)) {
       handlerInput.responseBuilder.addVideoAppLaunchDirective(videoUrl, 'Video Sample Title', 'Video Subtitle');
 


### PR DESCRIPTION
*Description of changes:*

Moves the url variable declaration into the Launch Handler. This will prevent errors if the sample is mostly used as-is and videoUrl is set to a presigned URL to a developer-supplied video hosted in an Alexa-hosted skill. The pre-signed URL expires after a minute, so if the Lambda container's lifetime is longer than one minute, and the url is set using the current code location, then the skill response will vend an expired URL. This would be fine (simply check the logs, fix the problem), however the error message is only on the client side (i.e. Echo Show) with nothing in CloudWatch logs, making it hard to debug, especially for someone new to skill development.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
