### PR TITLE
Update the Banana Stand skill to use the new Reminders API recurrence rules

### DIFF
--- a/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/index.js
+++ b/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/index.js
@@ -68,7 +68,7 @@ const CreateReminderIntentHandler = {
               "timeZoneId" : "America/Los_Angeles",
               "recurrence" : {                     
               "startDateTime": currentDateTime.format('YYYY-MM-DDTHH:mm:ss'),
-              // "endDateTime" : "2020-08-10T10:00:00.000", // Add this to specify the end date for recurring reminders
+              // "endDateTime" : "2020-08-10T10:00:00.000", // Add this to specify the end date for the recurring reminder
               "recurrenceRules" : [                                          
                   `FREQ=DAILY;BYHOUR=13;BYMINUTE=0;BYSECOND=0;INTERVAL=1;`
               ]               

--- a/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/index.js
+++ b/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/index.js
@@ -54,39 +54,40 @@ const CreateReminderIntentHandler = {
                 .getResponse();
         }
         
-        const currentDateTime = moment().tz('America/Los_Angeles'), // Use moment to get current date and time in Pacific Time.
+        const currentDateTime = moment().tz('America/Los_Angeles') // Use moment to get current date and time in Pacific Time.
             /* 
                 Declare the reminder request object that will be used by the reminderApiClient to send a POST request to the Reminders API.
                 The request object specifies a daily reminder at 1 p.m. (13:00:00) Pacific Time.
                 Reference: https://developer.amazon.com/docs/smapi/alexa-reminders-api-reference.html#request
             */
-            reminderRequest = {
-              requestTime: currentDateTime.format('YYYY-MM-DDTHH:mm:ss'),
-              trigger: {
-                type: 'SCHEDULED_ABSOLUTE',
-                scheduledTime: currentDateTime.set({
-                    hour: '13',
-                    minute: '00',
-                    second: '00'
-                }).format('YYYY-MM-DDTHH:mm:ss'),
-                timeZoneId: 'America/Los_Angeles',
-                recurrence: {
-                    freq: 'DAILY'
-                }
-              },
-              alertInfo: {
-                spokenInfo: {
-                  content: [{
-                    locale: 'en-US',
-                    text: 'Time to get yo banana',
-                  }],
-                },
-              },
-              pushNotification: {
-                status: 'ENABLED',
-              }
+        const reminderRequest = {
+          "requestTime" : currentDateTime.format('YYYY-MM-DDTHH:mm:ss'),
+          "trigger": {
+              "type" : "SCHEDULED_ABSOLUTE",
+              "scheduledTime" : currentDateTime.format('YYYY-MM-DDTHH:mm:ss'),
+              "timeZoneId" : "America/Los_Angeles",
+              "recurrence" : {                     
+              "startDateTime": currentDateTime.format('YYYY-MM-DDTHH:mm:ss'),
+              // "endDateTime" : "2020-08-10T10:00:00.000", // Add this to specify the end date for recurring reminders
+              "recurrenceRules" : [                                          
+                  `FREQ=DAILY;BYHOUR=13;BYMINUTE=0;BYSECOND=0;INTERVAL=1;`
+              ]               
             }
-        
+          },
+          "alertInfo": {
+              "spokenInfo": {
+                  "content": [{
+                      "locale": "en-US", 
+                      "text": "Time to get yo banana",
+                      "ssml": '<speak><amazon:emotion name="excited" intensity="high">Time to get yo banana</amazon:emotion></speak>'
+                  }]
+              }
+          },
+          "pushNotification" : {                            
+              "status" : "ENABLED"
+          }
+        }
+      
         try {
             /* Try to create a reminder based on the specified parameters in the request object. */
             await reminderApiClient.createReminder(reminderRequest)

--- a/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/package.json
+++ b/feature-demos/reminders-api/skill-demo-reminders-api-banana-stand/lambda/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "hello-world",
+  "name": "banana-stand-reminders-api",
   "version": "0.9.0",
-  "description": "alexa utility for quickly building skills",
+  "description": "Code sample that compliments https://youtu.be/eF7R4BEFu5c which demonstrates how to integrate the Reminders API into an Alexa skill.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Amazon Alexa",
+  "author": "Pan Wangperawong",
   "license": "ISC",
   "dependencies": {
     "ask-sdk-core": "^2.6.0",


### PR DESCRIPTION
*Description of changes:*
Update Banana Stand Reminders API skill to reflect the new recurrence rules based on the [Internet Calendaring and Scheduling (iCalendar)](https://tools.ietf.org/html/rfc5545#section-3.3.10) spec.

<!-- general checklist  -->
### Tests/checks which any code/configuration submission will need to pass
- [x] Adheres to any applicable [code style guidelines](../tree/master/guides/style) including linting
- [x] Code is i18n-ready (does not need to be translated/localized)
- [x] Does not utilize practices which would prevent certification
- [x] `ask deploy` successfully deploys skill and is ready for use
  > setup steps which are not achievable through the ASK CLI are exempted from this requirement
  > If multiple runtime languages are included, skill.json should use node.js or python version. 
- [x] Works in all locales for which interaction models have been supplied
- [x] Works on all devices (including simulator) which support any required features (special requirements must be called out in the README)
- [x] Documents any dependencies in the README
- [x] PR does not include any code dependencies (just includes the package.json, pom.xml, etc.)

<!--- * * * * * * * * * * * * --->
<!--- Do not delete the following section or your PR will be closed without comment. --->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
