### PR TITLE
Fix speak response: remove negative seconds in the freshness of the geolocation data

### DIFF
--- a/feature-demos/skill-demo-dynamic-location/lambda/custom/index.js
+++ b/feature-demos/skill-demo-dynamic-location/lambda/custom/index.js
@@ -66,6 +66,9 @@ const MyLocationIntentHandler = {
             // fetch geolocation data and use it in the response
             if (geoObject && geoObject.coordinate && geoObject.coordinate.accuracyInMeters < ACCURACY_THRESHOLD ) {
                 let freshness = (new Date(request.timestamp) - new Date(geoObject.timestamp)) / 1000; // freshness in seconds
+                if(freshness < 0) { // remove negative seconds
+                    freshness = 0;
+                }
 
                 const lat = geoObject.coordinate.latitudeInDegrees;
                 const lon = geoObject.coordinate.longitudeInDegrees;


### PR DESCRIPTION
### Issue/Patch/Bug Fix
*Issue #, if available:* None

*Description of changes:* Check the freshness of the geolocation data is negative seconds. If freshness is negative set value zero.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.