### PR TITLE
Fix timer label usage

### DIFF
--- a/feature-demos/skill-demo-timers/lambda/index.js
+++ b/feature-demos/skill-demo-timers/lambda/index.js
@@ -15,7 +15,7 @@ const TIMER_FUNCTION = getAnnouncementTimer;
 function getAnnouncementTimer(handlerInput, duration) {
     return {
         duration: duration,
-        label: handlerInput.t('ANNOUNCEMENT_TIMER_TITLE_MSG'),
+        timerLabel: handlerInput.t('ANNOUNCEMENT_TIMER_TITLE_MSG'),
         creationBehavior: {
             displayExperience: {
                 visibility: 'VISIBLE'
@@ -39,7 +39,7 @@ function getAnnouncementTimer(handlerInput, duration) {
 function getCustomTaskLaunchTimer(handlerInput, duration) {
     return {
         duration: duration,
-        label: handlerInput.t('TASK_TIMER_TITLE_MSG'),
+        timerLabel: handlerInput.t('TASK_TIMER_TITLE_MSG'),
         creationBehavior: {
             displayExperience: {
                 visibility: 'VISIBLE'
@@ -70,7 +70,7 @@ function getCustomTaskLaunchTimer(handlerInput, duration) {
 function getPredefinedTaskLaunchTimer(handlerInput, duration) {
     return {
         duration: duration,
-        label: handlerInput.t('TASK_TIMER_TITLE_MSG'),
+        timerLabel: handlerInput.t('TASK_TIMER_TITLE_MSG'),
         creationBehavior: {
             displayExperience: {
                 visibility: 'VISIBLE'


### PR DESCRIPTION
As per docs: https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-timers-api-reference.html#create-a-timer-operation-announce
the name of the field holding the timer's label is "timerLabel" (NOT "label").

Fixes https://github.com/alexa/alexa-cookbook/issues/274

<!--- *** Issue section *** --->
### Issue/Patch/Bug Fix
*Issue #, if available:* #274

*Description of changes:* Fix timer label usage (replaced `label` with `timerLabel`)



<!--- * * * * * * * * * * * * --->
<!--- Do not delete the following section or your PR will be closed without comment. --->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
