### PR TITLE
Fix broken getAttributes and saveAttributes when session is not available

### DIFF
--- a/tools/LocalPersistence/local_persist.class.js
+++ b/tools/LocalPersistence/local_persist.class.js
@@ -31,7 +31,7 @@ var localPersistenceAdapter = /** @class */ (function () {
 
   localPersistenceAdapter.prototype.getAttributes = function (request_envelope) {
     //get user ID and create shorter unique hash for filename
-    let userId = request_envelope.session.user.userId;
+    let userId = request_envelope.session? request_envelope.session.user.userId : request_envelope.context.System.user.userId;
     userId = sha(userId);
     var filepath = __dirname + "/" + this.pathPrefix + "/" + userId + ".json";
 
@@ -53,7 +53,7 @@ var localPersistenceAdapter = /** @class */ (function () {
    */
 
   localPersistenceAdapter.prototype.saveAttributes = function (request_envelope, attributes) {
-    var userId = request_envelope.session.user.userId;
+    var userId = request_envelope.session? request_envelope.session.user.userId : request_envelope.context.System.user.userId;
     userId = sha(userId);
     var save_path = __dirname + "/" + this.pathPrefix + "/" + userId + ".json";
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
https://github.com/alexa/alexa-cookbook/tree/master/tools/LocalPersistence
### Issue/Patch/Bug Fix
*Issue #, if available:*
None

*Description of changes:*
When using localPersistence Adapter, during out of session conditions/if a session is not available e.g. at times when  using at the AudioPlayer interface, getAttributes and saveAttributes will be broken as it is referring to request envelope's session property. fix is to check for such condition and if it exist, to get the userId from the context.System.user property.
